### PR TITLE
docs: add AIConfPaper to Libraries and Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,7 @@ Similarity Analysis of Acoustic Word Embeddings](https://arxiv.org/pdf/2109.1017
 - [AquilaDb](https://github.com/Aquila-Network/AquilaDB)
 - [STripNet](https://github.com/stephenleo/stripnet)
 - [ZhihuAgent](https://github.com/SamuelGong/ZhihuAgent)
+- [AIConfPaper - Semantic search over accepted AI-conference papers, with a REST API for agents.](https://aiconfpaper.com)
 
 ## Datasets
 - [Semantic Text Similarity Dataset Hub](https://github.com/brmson/dataset-sts)


### PR DESCRIPTION
Adds AIConfPaper to the **Libraries and Tools** section (last position), resolving #73.

[AIConfPaper](https://aiconfpaper.com) is a semantic search over accepted papers from major AI/ML/CV/NLP/robotics conferences, with a "similar papers" feature and a documented REST API for agents. It fits alongside the other semantic-search tools already listed.

Per CONTRIBUTING: added at the last position of the relevant section, and the description starts with a capital letter and ends with punctuation.
